### PR TITLE
Update FindILMBase.cmake

### DIFF
--- a/cmake/FindILMBase.cmake
+++ b/cmake/FindILMBase.cmake
@@ -63,7 +63,7 @@ foreach(_ilmbase_lib ${_ilmbase_REQUIRED_LIBS})
         endif()
     else()
         find_library(ILMBASE_${_ilmbase_lib}_LIBRARY ${_ilmbase_lib}
-            HINTS ${_ilmbase_ROOT}/lib
+            HINTS ${_ilmbase_ROOT_HINT}/lib
             DOC "ILMBase ${_ilmbase_lib} library path")
         list(APPEND _ilmbase_LIB_VARS "ILMBASE_${_ilmbase_lib}_LIBRARY")
         list(APPEND ILMBASE_LIBRARIES ${ILMBASE_${_ilmbase_lib}_LIBRARY})


### PR DESCRIPTION
FindILMBase.cmake was failing on my machine. I built both ILMBase and OpenEXR from source using the 2.2.0 tag, I used the CMake build system and ran the 'Install' project. I investigated and found that this hint in find_library() function didn't seem to be correct. I made this changed and tested it on my windows 7 64 bit machine using Visual Studio 2012 Update 4